### PR TITLE
Add configs

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,8 +1,8 @@
 services:
   onkyo-api:
-    build: .
+    build: ghcr.io/mtyszkiewicz/onkyo-api:latest
     ports:
-      - "8080:8080"
+      - "8001:8080"
     configs:
       - source: onkyo_config
         target: /onkyo_config

--- a/onkyo-ctl/cmd/api/main.go
+++ b/onkyo-ctl/cmd/api/main.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/mtyszkiewicz/eiscp/internal/config"
 	"github.com/mtyszkiewicz/eiscp/internal/pkg/eiscp"
 )
 
@@ -25,15 +27,10 @@ type Server struct {
 	profiles map[string]Profile
 }
 
-func NewServer(client *eiscp.EISCPClient) *Server {
+func NewServer(client *eiscp.EISCPClient, profiles map[string]Profile) *Server {
 	return &Server{
-		client: client,
-		profiles: map[string]Profile{
-			"tv":      {Name: "tv", VolumeLevel: 22, SubwooferLevel: 0, MaxVolume: 28},
-			"dj":      {Name: "dj", VolumeLevel: 27, SubwooferLevel: -4, MaxVolume: 35},
-			"vinyl":   {Name: "vinyl", VolumeLevel: 20, SubwooferLevel: 0, MaxVolume: 30},
-			"spotify": {Name: "spotify", VolumeLevel: 42, SubwooferLevel: 0, MaxVolume: 50},
-		},
+		client:   client,
+		profiles: profiles,
 	}
 }
 
@@ -74,7 +71,6 @@ func (s *Server) Routes() chi.Router {
 	return r
 }
 
-// Helper function to handle errors based on type
 func handleError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, eiscp.ErrValidation):
@@ -88,7 +84,6 @@ func handleError(w http.ResponseWriter, err error) {
 	}
 }
 
-// Power handlers
 func (s *Server) getPowerStatus(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, "Power status: on")
 }
@@ -109,7 +104,6 @@ func (s *Server) powerOff(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, "Power turned off")
 }
 
-// Volume handlers
 func (s *Server) getVolume(w http.ResponseWriter, r *http.Request) {
 	volume, err := s.client.QueryVolume()
 	if err != nil {
@@ -156,7 +150,6 @@ func (s *Server) setVolume(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Volume set to %d", level)
 }
 
-// Subwoofer handlers
 func (s *Server) getSubwoofer(w http.ResponseWriter, r *http.Request) {
 	level, err := s.client.QuerySubwooferLevel()
 	if err != nil {
@@ -203,7 +196,6 @@ func (s *Server) subwooferDown(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, "Subwoofer level: Down")
 }
 
-// Input handlers
 func (s *Server) getInput(w http.ResponseWriter, r *http.Request) {
 	input, err := s.client.QueryInputSelector()
 	if err != nil {
@@ -233,7 +225,6 @@ func (s *Server) setInput(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Input set to %s", name)
 }
 
-// Profile handlers
 func (s *Server) getProfile(w http.ResponseWriter, r *http.Request) {
 	currentInput, err := s.client.QueryInputSelector()
 	if err != nil {
@@ -303,13 +294,28 @@ func (s *Server) setProfile(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	client, err := eiscp.NewEISCPClient("10.205.0.163", "60128")
+	cfg, err := config.Load(os.Getenv("ONKYO_CONFIG"))
+	if err != nil {
+		log.Fatalf("Error loading config: %v", err)
+	}
+
+	client, err := eiscp.NewEISCPClient(cfg.Onkyo.Host, cfg.Onkyo.Port, cfg.InputCodes(), cfg.InputNames())
 	if err != nil {
 		log.Fatalf("Error connecting to server: %v", err)
 	}
 	defer client.Conn.Close()
 
+	profiles := make(map[string]Profile, len(cfg.Profiles))
+	for name, p := range cfg.Profiles {
+		profiles[name] = Profile{
+			Name:           name,
+			VolumeLevel:    p.VolumeLevel,
+			SubwooferLevel: p.SubwooferLevel,
+			MaxVolume:      p.MaxVolume,
+		}
+	}
+
 	log.Println("Connected to server")
-	server := NewServer(client)
+	server := NewServer(client, profiles)
 	log.Fatal(http.ListenAndServe(":8080", server.Routes()))
 }

--- a/onkyo-ctl/cmd/cli/main.go
+++ b/onkyo-ctl/cmd/cli/main.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/mtyszkiewicz/eiscp/internal/config"
 	"github.com/mtyszkiewicz/eiscp/internal/pkg/eiscp"
 	"github.com/urfave/cli/v3"
 )
@@ -23,23 +24,32 @@ func main() {
 				Name:    "host",
 				Aliases: []string{"H"},
 				Usage:   "Onkyo host ip address",
-				Value:   "127.0.0.1",
 				Sources: cli.EnvVars("ONKYO_HOST"),
 			},
 			&cli.StringFlag{
 				Name:    "port",
 				Aliases: []string{"P"},
 				Usage:   "Onkyo host port",
-				Value:   "60128",
 				Sources: cli.EnvVars("ONKYO_PORT"),
 			},
 		},
 		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
-			var err error
-			host := cmd.String("host")
-			port := cmd.String("port")
+			cfg, err := config.Load(os.Getenv("ONKYO_CONFIG"))
+			if err != nil {
+				return nil, fmt.Errorf("error loading config: %w", err)
+			}
 
-			client, err = eiscp.NewEISCPClient(host, port)
+			host := cmd.String("host")
+			if host == "" || host == "127.0.0.1" {
+				host = cfg.Onkyo.Host
+			}
+
+			port := cmd.String("port")
+			if port == "" || port == "60128" {
+				port = cfg.Onkyo.Port
+			}
+
+			client, err = eiscp.NewEISCPClient(host, port, cfg.InputCodes(), cfg.InputNames())
 			if err != nil {
 				return nil, fmt.Errorf("error connecting to server: %w", err)
 			}
@@ -170,24 +180,13 @@ func main() {
 					},
 					{
 						Name:  "set",
-						Usage: "Set input source (tv, spotify, dj, vinyl)",
+						Usage: "Set input source",
 						Action: func(ctx context.Context, cmd *cli.Command) error {
 							if cmd.Args().Len() != 1 {
 								return fmt.Errorf("usage: source set <source>")
 							}
 
 							source := strings.ToLower(cmd.Args().First())
-							validSources := map[string]bool{
-								"tv":      true,
-								"spotify": true,
-								"dj":      true,
-								"vinyl":   true,
-							}
-
-							if !validSources[source] {
-								return fmt.Errorf("invalid source '%s'. Available sources: tv, spotify, dj, vinyl", source)
-							}
-
 							return client.SetInputSelector(source)
 						},
 					},
@@ -196,10 +195,9 @@ func main() {
 						Usage: "List available input sources",
 						Action: func(ctx context.Context, cmd *cli.Command) error {
 							fmt.Println("Available sources:")
-							fmt.Println("  - tv")
-							fmt.Println("  - spotify")
-							fmt.Println("  - dj")
-							fmt.Println("  - vinyl")
+							for _, name := range client.ListInputs() {
+								fmt.Printf("  - %s\n", name)
+							}
 							return nil
 						},
 					},

--- a/onkyo-ctl/compose.yaml
+++ b/onkyo-ctl/compose.yaml
@@ -1,0 +1,40 @@
+services:
+  onkyo-api:
+    build: .
+    ports:
+      - "8080:8080"
+    configs:
+      - source: onkyo_config
+        target: /onkyo_config
+    environment:
+      - ONKYO_CONFIG=/onkyo_config
+    restart: unless-stopped
+
+configs:
+  onkyo_config:
+    content: |
+      onkyo:
+        host: "10.205.0.163"
+        port: "60128"
+
+      profiles:
+        tv:
+          code: "12"
+          volumeLevel: 22
+          subwooferLevel: 0
+          maxVolume: 28
+        dj:
+          code: "10"
+          volumeLevel: 27
+          subwooferLevel: -4
+          maxVolume: 35
+        vinyl:
+          code: "22"
+          volumeLevel: 20
+          subwooferLevel: 0
+          maxVolume: 30
+        spotify:
+          code: "01"
+          volumeLevel: 42
+          subwooferLevel: 0
+          maxVolume: 50

--- a/onkyo-ctl/go.mod
+++ b/onkyo-ctl/go.mod
@@ -3,11 +3,10 @@ module github.com/mtyszkiewicz/eiscp
 go 1.19
 
 require (
+	github.com/chzyer/readline v1.5.1
 	github.com/go-chi/chi/v5 v5.0.12
 	github.com/urfave/cli/v3 v3.0.0-beta1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
-require (
-	github.com/chzyer/readline v1.5.1 // indirect
-	golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5 // indirect
-)
+require golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5 // indirect

--- a/onkyo-ctl/go.sum
+++ b/onkyo-ctl/go.sum
@@ -1,6 +1,8 @@
+github.com/chzyer/logex v1.2.1 h1:XHDu3E6q+gdHgsdTPH6ImJMIp436vR6MPtH8gP05QzM=
 github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=
 github.com/chzyer/readline v1.5.1 h1:upd/6fQk4src78LMRzh5vItIt361/o4uq553V8B5sGI=
 github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObkaSkeBlk=
+github.com/chzyer/test v1.0.0 h1:p3BQDXSxOhOG0P9z6/hGnII4LGiEPOYBhs8asl/fC04=
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/go-chi/chi/v5 v5.0.12 h1:9euLV5sTrTNTRUU9POmDUvfxyj6LAABLUcEWO+JJb4s=
@@ -11,4 +13,7 @@ github.com/urfave/cli/v3 v3.0.0-beta1 h1:6DTaaUarcM0wX7qj5Hcvs+5Dm3dyUTBbEwIWAjc
 github.com/urfave/cli/v3 v3.0.0-beta1/go.mod h1:FnIeEMYu+ko8zP1F9Ypr3xkZMIDqW3DR92yUtY39q1Y=
 golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5 h1:y/woIyUBFbpQGKS0u1aHF/40WUDnek3fPOyD08H5Vng=
 golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/onkyo-ctl/internal/config/config.go
+++ b/onkyo-ctl/internal/config/config.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Config struct {
+	Onkyo    OnkyoConfig             `yaml:"onkyo"`
+	Profiles map[string]ProfileCfg   `yaml:"profiles"`
+}
+
+type OnkyoConfig struct {
+	Host string `yaml:"host"`
+	Port string `yaml:"port"`
+}
+
+type ProfileCfg struct {
+	Code           string `yaml:"code"`
+	VolumeLevel    int    `yaml:"volumeLevel"`
+	SubwooferLevel int    `yaml:"subwooferLevel"`
+	MaxVolume      int    `yaml:"maxVolume"`
+}
+
+func defaults() *Config {
+	return &Config{
+		Onkyo: OnkyoConfig{
+			Host: "10.205.0.163",
+			Port: "60128",
+		},
+		Profiles: map[string]ProfileCfg{
+			"tv":      {Code: "12", VolumeLevel: 22, SubwooferLevel: 0, MaxVolume: 28},
+			"dj":      {Code: "10", VolumeLevel: 27, SubwooferLevel: -4, MaxVolume: 35},
+			"vinyl":   {Code: "22", VolumeLevel: 20, SubwooferLevel: 0, MaxVolume: 30},
+			"spotify": {Code: "01", VolumeLevel: 42, SubwooferLevel: 0, MaxVolume: 50},
+		},
+	}
+}
+
+func Load(path string) (*Config, error) {
+	if path != "" {
+		cfg, err := loadFile(path)
+		if err == nil {
+			return cfg, nil
+		}
+	}
+
+	cfg, err := loadFile("/onkyo_config")
+	if err == nil {
+		return cfg, nil
+	}
+
+	return defaults(), nil
+}
+
+func loadFile(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse config file: %w", err)
+	}
+
+	if cfg.Onkyo.Host == "" {
+		cfg.Onkyo.Host = defaults().Onkyo.Host
+	}
+	if cfg.Onkyo.Port == "" {
+		cfg.Onkyo.Port = defaults().Onkyo.Port
+	}
+
+	return &cfg, nil
+}
+
+func (c *Config) InputCodes() map[string]string {
+	codes := make(map[string]string, len(c.Profiles))
+	for name, p := range c.Profiles {
+		codes[name] = p.Code
+	}
+	return codes
+}
+
+func (c *Config) InputNames() map[string]string {
+	names := make(map[string]string, len(c.Profiles))
+	for name, p := range c.Profiles {
+		names[p.Code] = name
+	}
+	return names
+}
+
+func (c *Config) InputList() []string {
+	names := make([]string, 0, len(c.Profiles))
+	for name := range c.Profiles {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/onkyo-ctl/internal/pkg/eiscp/client.go
+++ b/onkyo-ctl/internal/pkg/eiscp/client.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -20,9 +21,11 @@ var (
 type EISCPClient struct {
 	Conn          net.Conn
 	responseQueue chan string
+	inputCodes    map[string]string
+	inputNames    map[string]string
 }
 
-func NewEISCPClient(host, port string) (*EISCPClient, error) {
+func NewEISCPClient(host, port string, inputCodes, inputNames map[string]string) (*EISCPClient, error) {
 	serverAddress := net.JoinHostPort(host, port)
 	conn, err := net.DialTimeout("tcp", serverAddress, 5*time.Second)
 	if err != nil {
@@ -31,6 +34,8 @@ func NewEISCPClient(host, port string) (*EISCPClient, error) {
 	client := &EISCPClient{
 		Conn:          conn,
 		responseQueue: make(chan string, 100),
+		inputCodes:    inputCodes,
+		inputNames:    inputNames,
 	}
 	go client.listen()
 	return client, nil
@@ -79,18 +84,36 @@ func (c *EISCPClient) SendReceiveCommand(command string) (string, error) {
 	}
 }
 
-var inputCodes = map[string]string{
-	"spotify": "01",
-	"vinyl":   "22",
-	"tv":      "12",
-	"dj":      "10",
+func (c *EISCPClient) SetInputSelector(input string) error {
+	code, ok := c.inputCodes[input]
+	if !ok {
+		return fmt.Errorf("%w: invalid input selector '%s'", ErrValidation, input)
+	}
+	return c.SendCommand("SLI" + code)
 }
 
-var inputNames = map[string]string{
-	"01": "spotify",
-	"22": "vinyl",
-	"12": "tv",
-	"10": "dj",
+func (c *EISCPClient) QueryInputSelector() (string, error) {
+	response, err := c.SendReceiveCommand("SLIQSTN")
+	if err != nil {
+		return "", err
+	}
+
+	code := strings.TrimPrefix(response, "SLI")
+
+	name, ok := c.inputNames[code]
+	if !ok {
+		return "", fmt.Errorf("%w: unknown input code '%s'", ErrValidation, code)
+	}
+	return name, nil
+}
+
+func (c *EISCPClient) ListInputs() []string {
+	names := make([]string, 0, len(c.inputCodes))
+	for name := range c.inputCodes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 func (c *EISCPClient) PowerOn() error {
@@ -138,30 +161,6 @@ func (c *EISCPClient) SetSubwooferLevel(level int) error {
 	}
 
 	return c.SendCommand(command)
-}
-
-func (c *EISCPClient) SetInputSelector(input string) error {
-	code, ok := inputCodes[input]
-	if !ok {
-		return fmt.Errorf("%w: invalid input selector '%s'", ErrValidation, input)
-	}
-	return c.SendCommand("SLI" + code)
-}
-
-func (c *EISCPClient) QueryInputSelector() (string, error) {
-	response, err := c.SendReceiveCommand("SLIQSTN")
-	if err != nil {
-		return "", err
-	}
-
-	code := strings.TrimPrefix(response, "SLI")
-	// fmt.Printf("Received input code: '%s' (length: %d)\n", code, len(code))
-
-	name, ok := inputNames[code]
-	if !ok {
-		return "", fmt.Errorf("%w: unknown input code '%s'", ErrValidation, code)
-	}
-	return name, nil
 }
 
 func (c *EISCPClient) QueryVolume() (int, error) {


### PR DESCRIPTION
Add global config for fine-tuning volume levels on profiles. To accomplish this I used Docker Compose configs to keep all configs localized in a single compose.yaml. This way you only update the compose file and run a restart while fine-tuning.

Used opencode + DeepSeek v3 pro, $1